### PR TITLE
feat: Add a new `beginSPI` method using a SPI interface reference

### DIFF
--- a/PL_ADXL355.cpp
+++ b/PL_ADXL355.cpp
@@ -140,10 +140,23 @@ void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency) {
   interface = ADXL355_Interface::spi;
   spiFrequency = frequency;
   this->csPin = csPin;
+  spiBus = SPI;
 
   spiSettings = SPISettings(spiFrequency, MSBFIRST, SPI_MODE0);
 
-  SPI.begin();
+  spiBus.begin();
+  pinMode(csPin, OUTPUT);
+  digitalWrite(csPin, HIGH);
+}
+
+void ADXL355::beginSPI(SPIClass& spiBus, uint8_t csPin, uint32_t frequency) {
+  interface = ADXL355_Interface::spi;
+  spiFrequency = frequency;
+  this->csPin = csPin;
+  this->spiBus = spiBus;
+
+  spiSettings = SPISettings(spiFrequency, MSBFIRST, SPI_MODE0);
+
   pinMode(csPin, OUTPUT);
   digitalWrite(csPin, HIGH);
 }
@@ -642,12 +655,12 @@ void ADXL355::read(uint8_t address, void* dest, size_t numberOfRegisters) {
   memset(dest, 0, numberOfRegisters);
 
   if (interface == ADXL355_Interface::spi) {
-    SPI.beginTransaction(spiSettings);
+    spiBus.beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    SPI.transfer((address << 1) | 1);
-    SPI.transfer(dest, numberOfRegisters);
+    spiBus.transfer((address << 1) | 1);
+    spiBus.transfer(dest, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    SPI.endTransaction();
+    spiBus.endTransaction();
   }
 
   if (interface == ADXL355_Interface::i2c) {
@@ -674,12 +687,12 @@ void ADXL355::write(uint8_t address, void* src, size_t numberOfRegisters) {
     return;
 
   if (interface == ADXL355_Interface::spi) {
-    SPI.beginTransaction(spiSettings);
+    spiBus.beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    SPI.transfer(address << 1);
-    SPI.transfer(src, numberOfRegisters);
+    spiBus.transfer(address << 1);
+    spiBus.transfer(src, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    SPI.endTransaction(); 
+    spiBus.endTransaction(); 
   }
 
   if (interface == ADXL355_Interface::i2c) {

--- a/PL_ADXL355.cpp
+++ b/PL_ADXL355.cpp
@@ -136,15 +136,16 @@ ADXL355::ADXL355(uint8_t csPin, uint32_t frequency) : interface(ADXL355_Interfac
 
 //==============================================================================
 
-void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency, SPIClass spi) {
+void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency, std::shared_ptr<SPIClass> customSPI) {
   interface = ADXL355_Interface::spi;
-  this->spi = spi;
+  this->customSPI = customSPI;
+  this->spi = customSPI ? customSPI.get() : &SPI;
   this->csPin = csPin;
   spiFrequency = frequency;
 
   spiSettings = SPISettings(spiFrequency, MSBFIRST, SPI_MODE0);
 
-  spi.begin();
+  spi->begin();
   pinMode(csPin, OUTPUT);
   digitalWrite(csPin, HIGH);
 }
@@ -643,12 +644,12 @@ void ADXL355::read(uint8_t address, void* dest, size_t numberOfRegisters) {
   memset(dest, 0, numberOfRegisters);
 
   if (interface == ADXL355_Interface::spi) {
-    spi.beginTransaction(spiSettings);
+    spi->beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    spi.transfer((address << 1) | 1);
-    spi.transfer(dest, numberOfRegisters);
+    spi->transfer((address << 1) | 1);
+    spi->transfer(dest, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    spi.endTransaction();
+    spi->endTransaction();
   }
 
   if (interface == ADXL355_Interface::i2c) {
@@ -675,12 +676,12 @@ void ADXL355::write(uint8_t address, void* src, size_t numberOfRegisters) {
     return;
 
   if (interface == ADXL355_Interface::spi) {
-    spi.beginTransaction(spiSettings);
+    spi->beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    spi.transfer(address << 1);
-    spi.transfer(src, numberOfRegisters);
+    spi->transfer(address << 1);
+    spi->transfer(src, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    spi.endTransaction(); 
+    spi->endTransaction(); 
   }
 
   if (interface == ADXL355_Interface::i2c) {

--- a/PL_ADXL355.cpp
+++ b/PL_ADXL355.cpp
@@ -132,31 +132,19 @@ ADXL355::ADXL355() {}
 
 //==============================================================================
 
-ADXL355::ADXL355(uint8_t csPin, uint32_t frequency) : interface(ADXL355_Interface::spi), spiFrequency(frequency), csPin(csPin) {}
+ADXL355::ADXL355(uint8_t csPin, uint32_t frequency) : interface(ADXL355_Interface::spi), csPin(csPin), spiFrequency(frequency) {}
 
 //==============================================================================
 
-void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency) {
+void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency, SPIClass spi) {
   interface = ADXL355_Interface::spi;
-  spiFrequency = frequency;
+  this->spi = spi;
   this->csPin = csPin;
-  spiBus = SPI;
+  spiFrequency = frequency;
 
   spiSettings = SPISettings(spiFrequency, MSBFIRST, SPI_MODE0);
 
-  spiBus.begin();
-  pinMode(csPin, OUTPUT);
-  digitalWrite(csPin, HIGH);
-}
-
-void ADXL355::beginSPI(SPIClass& spiBus, uint8_t csPin, uint32_t frequency) {
-  interface = ADXL355_Interface::spi;
-  spiFrequency = frequency;
-  this->csPin = csPin;
-  this->spiBus = spiBus;
-
-  spiSettings = SPISettings(spiFrequency, MSBFIRST, SPI_MODE0);
-
+  spi.begin();
   pinMode(csPin, OUTPUT);
   digitalWrite(csPin, HIGH);
 }
@@ -655,12 +643,12 @@ void ADXL355::read(uint8_t address, void* dest, size_t numberOfRegisters) {
   memset(dest, 0, numberOfRegisters);
 
   if (interface == ADXL355_Interface::spi) {
-    spiBus.beginTransaction(spiSettings);
+    spi.beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    spiBus.transfer((address << 1) | 1);
-    spiBus.transfer(dest, numberOfRegisters);
+    spi.transfer((address << 1) | 1);
+    spi.transfer(dest, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    spiBus.endTransaction();
+    spi.endTransaction();
   }
 
   if (interface == ADXL355_Interface::i2c) {
@@ -687,12 +675,12 @@ void ADXL355::write(uint8_t address, void* src, size_t numberOfRegisters) {
     return;
 
   if (interface == ADXL355_Interface::spi) {
-    spiBus.beginTransaction(spiSettings);
+    spi.beginTransaction(spiSettings);
     digitalWrite(csPin, LOW);
-    spiBus.transfer(address << 1);
-    spiBus.transfer(src, numberOfRegisters);
+    spi.transfer(address << 1);
+    spi.transfer(src, numberOfRegisters);
     digitalWrite(csPin, HIGH);
-    spiBus.endTransaction(); 
+    spi.endTransaction(); 
   }
 
   if (interface == ADXL355_Interface::i2c) {

--- a/PL_ADXL355.cpp
+++ b/PL_ADXL355.cpp
@@ -138,8 +138,8 @@ ADXL355::ADXL355(uint8_t csPin, uint32_t frequency) : interface(ADXL355_Interfac
 
 void ADXL355::beginSPI(uint8_t csPin, uint32_t frequency, std::shared_ptr<SPIClass> customSPI) {
   interface = ADXL355_Interface::spi;
-  this->customSPI = customSPI;
-  this->spi = customSPI ? customSPI.get() : &SPI;
+  this->customSPI = customSPI; // Custom SPI bus shared pointer (stored to guarantee custom SPI bus object lifetime)
+  this->spi = customSPI ? customSPI.get() : &SPI; // Custom or default SPI bus pointer (used in transactions)
   this->csPin = csPin;
   spiFrequency = frequency;
 

--- a/PL_ADXL355.h
+++ b/PL_ADXL355.h
@@ -2,6 +2,7 @@
 #define PL_ADXL355_H
 
 #include <Arduino.h>
+#include <memory>
 #include <SPI.h>
 #include <Wire.h>
 
@@ -253,8 +254,8 @@ public:
   /// @brief Initializes the SPI bus and the CS pin
   /// @param csPin SPI chip select pin
   /// @param frequency SPI frequency, Hz
-  /// @param spi SPI bus
-  void beginSPI(uint8_t csPin, uint32_t frequency = defaultSpiFrequency, SPIClass spi = SPI);
+  /// @param customSPI Custom SPI bus
+  void beginSPI(uint8_t csPin, uint32_t frequency = defaultSpiFrequency, std::shared_ptr<SPIClass> customSPI = NULL);
 
   /// @brief Initializes the I2C bus
   /// @param address I2C target address (0x1D if ASEL = 0 or 0x53 if ASEL = 1)
@@ -474,7 +475,8 @@ public:
 private:
   ADXL355_Interface interface = ADXL355_Interface::unknown;
 
-  SPIClass spi = SPI;
+  std::shared_ptr<SPIClass> customSPI = NULL;
+  SPIClass* spi = &SPI;
   uint8_t csPin;
   uint32_t spiFrequency;
   SPISettings spiSettings;

--- a/PL_ADXL355.h
+++ b/PL_ADXL355.h
@@ -254,7 +254,7 @@ public:
   /// @brief Initializes the SPI bus and the CS pin
   /// @param csPin SPI chip select pin
   /// @param frequency SPI frequency, Hz
-  /// @param customSPI Custom SPI bus
+  /// @param customSPI Custom SPI bus (std::shared_ptr<SPIClass> can be created using std::make_shared<SPIClass>(...SPIClass constructor arguments...) )
   void beginSPI(uint8_t csPin, uint32_t frequency = defaultSpiFrequency, std::shared_ptr<SPIClass> customSPI = NULL);
 
   /// @brief Initializes the I2C bus
@@ -475,8 +475,8 @@ public:
 private:
   ADXL355_Interface interface = ADXL355_Interface::unknown;
 
-  std::shared_ptr<SPIClass> customSPI = NULL;
-  SPIClass* spi = &SPI;
+  std::shared_ptr<SPIClass> customSPI = NULL; // Custom SPI bus shared pointer (stored to guarantee custom SPI bus object lifetime)
+  SPIClass* spi = &SPI; // Custom or default SPI bus pointer (used in transactions)
   uint8_t csPin;
   uint32_t spiFrequency;
   SPISettings spiSettings;

--- a/PL_ADXL355.h
+++ b/PL_ADXL355.h
@@ -250,21 +250,11 @@ public:
   __attribute__((deprecated("Use parameterless constructor instead and select the interface by using beginSPI or beginI2C.")))
   ADXL355(uint8_t csPin, uint32_t frequency = defaultSpiFrequency);
 
-  /// @brief Initializes the default Arduino SPI bus and the CS pin
+  /// @brief Initializes the SPI bus and the CS pin
   /// @param csPin SPI chip select pin
   /// @param frequency SPI frequency, Hz
-  void beginSPI(uint8_t csPin, uint32_t frequency = defaultSpiFrequency);
-
-  /// @brief Initializes the internal SPI context with the provided parameters.
-  /// @param csPin SPI chip select pin
-  /// @param frequency SPI frequency, Hz
-  /// @param spiBus SPI bus to use.
-  /// @warning  The whole point of this method is to allow users to use their own SPI interface
-  ///           to communicate with the ADXL355 accelerometer. The responsibility of calling
-  ///           the `begin` method of the provided SPI interface therefore falls on the user of this method.
-  /// @warning  Since the SPI interface is provided (and stored) as a reference,
-  ///           *it must never go out of scope before this object!!*
-  void beginSPI(SPIClass& spiBus, uint8_t csPin, uint32_t frequency = defaultSpiFrequency);
+  /// @param spi SPI bus
+  void beginSPI(uint8_t csPin, uint32_t frequency = defaultSpiFrequency, SPIClass spi = SPI);
 
   /// @brief Initializes the I2C bus
   /// @param address I2C target address (0x1D if ASEL = 0 or 0x53 if ASEL = 1)
@@ -484,18 +474,13 @@ public:
 private:
   ADXL355_Interface interface = ADXL355_Interface::unknown;
 
-  // I²C Context
+  SPIClass spi = SPI;
+  uint8_t csPin;
+  uint32_t spiFrequency;
+  SPISettings spiSettings;
+  
   uint8_t i2cAddress;
   uint32_t i2cFrequency;
-
-  // SPI Context
-  uint32_t spiFrequency;  // LEGACY From SPI-bound constructor.
-  uint8_t csPin;
-  SPISettings spiSettings;
-
-  // Reference to an existing SPI bus. Defaults to the Arduino global bus
-  // to avoid juggling with `optional` shenanigans, or breaking the existing interface.
-  SPIClass& spiBus = SPI;
 
   uint8_t read(uint8_t address);
   void read(uint8_t address, void* dest, size_t numberOfRegisters);


### PR DESCRIPTION
This opens the possibility of using the ADXL355 on a SPI bus with custom pins.